### PR TITLE
Fix copy value context menu option

### DIFF
--- a/cutevariant/gui/plugins/query_view/widgets.py
+++ b/cutevariant/gui/plugins/query_view/widgets.py
@@ -479,7 +479,7 @@ class QueryViewWidget(plugin.PluginWidget):
         cell_value = self.model.variant(index)[index.column()]
         menu.addAction(FIcon(0xf18f),
         f"Copy {cell_value}", 
-        lambda : qApp.clipboard().setText(str(self.model.variant(index)))
+        lambda : qApp.clipboard().setText(str(cell_value))
         )
 
         genomic_location = "{chr}:{pos}{ref}>{alt}".format(**variant)


### PR DESCRIPTION
The option to copy the value of the current cell is currently broken. It copies the whole line as a list. This simple fix restores the correct behavior.