### PR TITLE
include default_config.yml in MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -32,4 +32,4 @@ recursive-include cutevariant/gui/plugins *.json
 include cutevariant/assets/i18n/*.qm
 exclude cutevariant/assets/i18n/*.ts
 include cutevariant/assets/LICENSE
-
+include cutevariant/default_config.yml


### PR DESCRIPTION
Hello,

Thanks for this nice tool! 

`cutevariant/default_config.yml` was missing when installing from source/PyPi.

Execute cutevariant raised the following error:
`FileNotFoundError: [Errno 2] No such file or directory: 'XXX/cutevariant/default_config.yml'`


