### PR TITLE
issue #288 HAS operator with comma and &, some fix

### DIFF
--- a/cutevariant/commons.py
+++ b/cutevariant/commons.py
@@ -121,6 +121,9 @@ LOG_LEVELS = {
     "notset": logging.NOTSET,
 }
 
+# OPERATOR HAS
+HAS_OPERATOR=","
+
 ################################################################################
 def create_logger():
     logger = logging.getLogger(__name__)

--- a/cutevariant/core/querybuilder.py
+++ b/cutevariant/core/querybuilder.py
@@ -53,6 +53,8 @@ PY_TO_SQL_OPERATORS = {
     "$or": "OR",
     "$has": "HAS",
     "$nhas": "NOT HAS",
+    "$ha&": "HA&",
+    "$nha&": "NOT HA&",
 }
 
 PY_TO_VQL_OPERATORS = {
@@ -70,6 +72,8 @@ PY_TO_VQL_OPERATORS = {
     "$or": "OR",
     "$has": "HAS",
     "$nhas": "!HAS",
+    "$ha&": "HA&",
+    "$nha&": "!HA&",
 }
 
 
@@ -335,11 +339,17 @@ def condition_to_sql(item: dict, samples=None) -> str:
             value = f"%{value}%"
 
     if "HAS" in sql_operator:
-        field = f"'&' || {field} || '&'"
+        field = f"',' || {field} || ','"
         sql_operator = "LIKE" if sql_operator == "HAS" else "NOT LIKE"
-        value = f"%&{value}&%"
+        value = f"%,{value},%"
 
         # WHERE '&' || consequence || '&' LIKE "%&missense_variant&%"
+
+    if "HA&" in sql_operator:
+        field = f"'&' || {field} || '&'"
+        sql_operator = "LIKE" if sql_operator == "HA&" else "NOT LIKE"
+        value = f"%&{value}&%"
+
 
     # Cast value
     if isinstance(value, str):

--- a/cutevariant/core/querybuilder.py
+++ b/cutevariant/core/querybuilder.py
@@ -28,6 +28,7 @@ from ast import literal_eval
 
 # Custom imports
 from cutevariant.core import sql
+import cutevariant.commons as cm
 
 
 from cutevariant import LOGGER
@@ -53,8 +54,6 @@ PY_TO_SQL_OPERATORS = {
     "$or": "OR",
     "$has": "HAS",
     "$nhas": "NOT HAS",
-    "$ha&": "HA&",
-    "$nha&": "NOT HA&",
 }
 
 PY_TO_VQL_OPERATORS = {
@@ -72,8 +71,6 @@ PY_TO_VQL_OPERATORS = {
     "$or": "OR",
     "$has": "HAS",
     "$nhas": "!HAS",
-    "$ha&": "HA&",
-    "$nha&": "!HA&",
 }
 
 
@@ -339,16 +336,11 @@ def condition_to_sql(item: dict, samples=None) -> str:
             value = f"%{value}%"
 
     if "HAS" in sql_operator:
-        field = f"',' || {field} || ','"
+        field = f"'{cm.HAS_OPERATOR}' || {field} || '{cm.HAS_OPERATOR}'"
         sql_operator = "LIKE" if sql_operator == "HAS" else "NOT LIKE"
-        value = f"%,{value},%"
+        value = f"%{cm.HAS_OPERATOR}{value}{cm.HAS_OPERATOR}%"
 
         # WHERE '&' || consequence || '&' LIKE "%&missense_variant&%"
-
-    if "HA&" in sql_operator:
-        field = f"'&' || {field} || '&'"
-        sql_operator = "LIKE" if sql_operator == "HA&" else "NOT LIKE"
-        value = f"%&{value}&%"
 
 
     # Cast value

--- a/cutevariant/gui/formatters/cutestyle.py
+++ b/cutevariant/gui/formatters/cutestyle.py
@@ -154,7 +154,7 @@ class CutestyleFormatter(Formatter):
             if value is None or value == "":
                 return {}
 
-            values = str(value).split("&")
+            values = str(value).split(",")
             font = QFont()
             metrics = QFontMetrics(font)
             x = 0

--- a/cutevariant/gui/plugins/filters_editor/widgets.py
+++ b/cutevariant/gui/plugins/filters_editor/widgets.py
@@ -121,8 +121,6 @@ OPERATOR_VQL_TO_NAME = {
     "$or": "Or",
     "$has": "Has",
     "$nhas": "Has not",
-    "$ha&": "Has (with '&')",
-    "$nha&": "Has not (with '&')",
 }
 
 

--- a/cutevariant/gui/plugins/filters_editor/widgets.py
+++ b/cutevariant/gui/plugins/filters_editor/widgets.py
@@ -121,6 +121,8 @@ OPERATOR_VQL_TO_NAME = {
     "$or": "Or",
     "$has": "Has",
     "$nhas": "Has not",
+    "$ha&": "Has (with '&')",
+    "$nha&": "Has not (with '&')",
 }
 
 

--- a/cutevariant/gui/widgets/sample_variant_widget.py
+++ b/cutevariant/gui/widgets/sample_variant_widget.py
@@ -29,7 +29,7 @@ class SampleVariantWidget(QWidget):
             self.TAG_LIST = [tag["name"] for tag in Config("validation")["validation_tags"]]
         else:
             self.TAG_LIST = []
-        self.TAG_SEPARATOR = "&"
+        self.TAG_SEPARATOR = ","
         self.REVERSE_CLASSIF = {
             v["name"]: k for k, v in SAMPLE_VARIANT_CLASSIFICATION.items()
         }
@@ -261,7 +261,7 @@ class SampleVariantWidget(QWidget):
         #avoid losing tags who exist in DB but not in config.yml
         missing_tags = []
         for tag in self.initial_db_validation["tags"].split(self.TAG_SEPARATOR):
-            if tag not in self.TAG_LIST:
+            if tag not in self.TAG_LIST and tag != '':
                 missing_tags.append(tag)
 
         update_data = {

--- a/cutevariant/gui/widgets/sample_variant_widget.py
+++ b/cutevariant/gui/widgets/sample_variant_widget.py
@@ -13,6 +13,7 @@ from cutevariant.gui.ficon import FIcon
 
 from cutevariant.gui.widgets.multi_combobox import MultiComboBox
 
+import cutevariant.commons as cm
 
 class QHLine(QFrame):
     def __init__(self):
@@ -29,7 +30,7 @@ class SampleVariantWidget(QWidget):
             self.TAG_LIST = [tag["name"] for tag in Config("validation")["validation_tags"]]
         else:
             self.TAG_LIST = []
-        self.TAG_SEPARATOR = ","
+        self.TAG_SEPARATOR = cm.HAS_OPERATOR
         self.REVERSE_CLASSIF = {
             v["name"]: k for k, v in SAMPLE_VARIANT_CLASSIFICATION.items()
         }

--- a/cutevariant/gui/widgets/sample_widget.py
+++ b/cutevariant/gui/widgets/sample_widget.py
@@ -49,7 +49,7 @@ class SampleWidget(QWidget):
             self.TAG_LIST = [tag["name"] for tag in Config("validation")["sample_tags"]]
         else:
             self.TAG_LIST = []
-        self.TAG_SEPARATOR = "&"
+        self.TAG_SEPARATOR = ","
         self.SAMPLE_CLASSIFICATION = {
             -1: {"name": "Rejected"},
             0: {"name": "Unlocked"},
@@ -202,7 +202,7 @@ class SampleWidget(QWidget):
         # avoid losing tags who exist in DB but not in config.yml
         missing_tags = []
         for tag in self.initial_db_validation["tags"].split(self.TAG_SEPARATOR):
-            if tag not in self.TAG_LIST:
+            if tag not in self.TAG_LIST and tag != '':
                 missing_tags.append(tag)
 
         data = {

--- a/cutevariant/gui/widgets/sample_widget.py
+++ b/cutevariant/gui/widgets/sample_widget.py
@@ -12,6 +12,9 @@ from cutevariant.gui.ficon import FIcon
 from cutevariant.gui.widgets import ChoiceWidget, DictWidget
 from cutevariant.gui.widgets.multi_combobox import MultiComboBox
 
+import cutevariant.commons as cm
+
+from cutevariant.gui.style import CLASSIFICATION, SAMPLE_CLASSIFICATION
 
 class HpoWidget(QWidget):
     def __init__(self, parent=None):
@@ -49,14 +52,14 @@ class SampleWidget(QWidget):
             self.TAG_LIST = [tag["name"] for tag in Config("validation")["sample_tags"]]
         else:
             self.TAG_LIST = []
-        self.TAG_SEPARATOR = ","
-        self.SAMPLE_CLASSIFICATION = {
-            -1: {"name": "Rejected"},
-            0: {"name": "Unlocked"},
-            1: {"name": "Locked"},
-        }
+        self.TAG_SEPARATOR = cm.HAS_OPERATOR
+        # self.SAMPLE_CLASSIFICATION = {
+        #     -1: {"name": "Rejected"},
+        #     0: {"name": "Unlocked"},
+        #     1: {"name": "Locked"},
+        # }
         self.REVERSE_CLASSIF = {
-            v["name"]: k for k, v in self.SAMPLE_CLASSIFICATION.items()
+            v["name"]: k for k, v in SAMPLE_CLASSIFICATION.items()
         }
 
         # Identity
@@ -157,7 +160,7 @@ class SampleWidget(QWidget):
         self.phenotype_combo.setCurrentIndex(data.get("phenotype", 0))
 
         # self.classification.addItems([v["name"] for v in self.SAMPLE_CLASSIFICATION.values()])
-        for k, v in self.SAMPLE_CLASSIFICATION.items():
+        for k, v in SAMPLE_CLASSIFICATION.items():
             self.classification.addItem(v["name"], k)
         index = self.classification.findData(data["valid"])
         self.classification.setCurrentIndex(index)

--- a/cutevariant/gui/widgets/variant_widget.py
+++ b/cutevariant/gui/widgets/variant_widget.py
@@ -53,7 +53,7 @@ class VariantWidget(QWidget):
             self.TAG_LIST = [tag["name"] for tag in Config("variant_view")["tags"]]
         else:
             self.TAG_LIST = []
-        self.TAG_SEPARATOR = "&"
+        self.TAG_SEPARATOR = ","
         self.REVERSE_CLASSIF = {v["name"]: k for k, v in CLASSIFICATION.items()}
         self._conn = conn
 
@@ -184,7 +184,7 @@ class VariantWidget(QWidget):
         #avoid losing tags who exist in DB but not in config.yml
         missing_tags = []
         for tag in self.initial_db_validation["tags"].split(self.TAG_SEPARATOR):
-            if tag not in self.TAG_LIST:
+            if tag not in self.TAG_LIST and tag != '':
                 missing_tags.append(tag)
 
         update_data = {"id": self.data["id"]}

--- a/cutevariant/gui/widgets/variant_widget.py
+++ b/cutevariant/gui/widgets/variant_widget.py
@@ -20,6 +20,7 @@ from PySide6.QtWidgets import (
 )
 from PySide6.QtCore import Qt, QSortFilterProxyModel, QAbstractTableModel
 
+import cutevariant.commons as cm
 
 class TableModel(QAbstractTableModel):
     def __init__(self, data=None):
@@ -53,7 +54,7 @@ class VariantWidget(QWidget):
             self.TAG_LIST = [tag["name"] for tag in Config("variant_view")["tags"]]
         else:
             self.TAG_LIST = []
-        self.TAG_SEPARATOR = ","
+        self.TAG_SEPARATOR = cm.HAS_OPERATOR
         self.REVERSE_CLASSIF = {v["name"]: k for k, v in CLASSIFICATION.items()}
         self._conn = conn
 

--- a/tests/core/test_querybuilder.py
+++ b/tests/core/test_querybuilder.py
@@ -549,27 +549,6 @@ QUERY_TESTS = [
         "SELECT DISTINCT `variants`.`id`,`variants`.`chr`,`variants`.`pos` FROM variants INNER JOIN sample_has_variant `sample_TUMOR` ON `sample_TUMOR`.variant_id = variants.id AND `sample_TUMOR`.sample_id = 1 INNER JOIN sample_has_variant `sample_NORMAL` ON `sample_NORMAL`.variant_id = variants.id AND `sample_NORMAL`.sample_id = 2 WHERE ((`sample_TUMOR`.`gt` = 1 OR `sample_NORMAL`.`gt` = 1)) LIMIT 50 OFFSET 0",
         "SELECT chr,pos FROM variants WHERE samples[ANY].gt = 1",
     ),
-    # TEST HA&
-    # Test filters with HA& !
-    (
-        {
-            "fields": ["chr", "pos", "ref", "alt"],
-            "source": "variants",
-            "filters": {"$and": [{"ref": {"$ha&": "variant"}}]},
-        },
-        "SELECT DISTINCT `variants`.`id`,`variants`.`chr`,`variants`.`pos`,`variants`.`ref`,`variants`.`alt` FROM variants WHERE ('&' || `variants`.`ref` || '&' LIKE '%&variant&%') LIMIT 50 OFFSET 0",
-        "SELECT chr,pos,ref,alt FROM variants WHERE ref HA& 'variant'",
-    ),
-    # TEST NOT HA&
-    (
-        {
-            "fields": ["chr", "pos", "ref", "alt"],
-            "source": "variants",
-            "filters": {"$and": [{"ref": {"$nha&": "variant"}}]},
-        },
-        "SELECT DISTINCT `variants`.`id`,`variants`.`chr`,`variants`.`pos`,`variants`.`ref`,`variants`.`alt` FROM variants WHERE ('&' || `variants`.`ref` || '&' NOT LIKE '%&variant&%') LIMIT 50 OFFSET 0",
-        "SELECT chr,pos,ref,alt FROM variants WHERE ref !HA& 'variant'",
-    ),
     # TEST ANY
     (
         {

--- a/tests/core/test_querybuilder.py
+++ b/tests/core/test_querybuilder.py
@@ -558,7 +558,7 @@ QUERY_TESTS = [
             "filters": {"$and": [{"ref": {"$ha&": "variant"}}]},
         },
         "SELECT DISTINCT `variants`.`id`,`variants`.`chr`,`variants`.`pos`,`variants`.`ref`,`variants`.`alt` FROM variants WHERE ('&' || `variants`.`ref` || '&' LIKE '%&variant&%') LIMIT 50 OFFSET 0",
-        "SELECT chr,pos,ref,alt FROM variants WHERE ref HAS 'variant'",
+        "SELECT chr,pos,ref,alt FROM variants WHERE ref HA& 'variant'",
     ),
     # TEST NOT HA&
     (
@@ -568,7 +568,7 @@ QUERY_TESTS = [
             "filters": {"$and": [{"ref": {"$nha&": "variant"}}]},
         },
         "SELECT DISTINCT `variants`.`id`,`variants`.`chr`,`variants`.`pos`,`variants`.`ref`,`variants`.`alt` FROM variants WHERE ('&' || `variants`.`ref` || '&' NOT LIKE '%&variant&%') LIMIT 50 OFFSET 0",
-        "SELECT chr,pos,ref,alt FROM variants WHERE ref !HAS 'variant'",
+        "SELECT chr,pos,ref,alt FROM variants WHERE ref !HA& 'variant'",
     ),
     # TEST ANY
     (

--- a/tests/core/test_querybuilder.py
+++ b/tests/core/test_querybuilder.py
@@ -527,7 +527,7 @@ QUERY_TESTS = [
             "source": "variants",
             "filters": {"$and": [{"ref": {"$has": "variant"}}]},
         },
-        "SELECT DISTINCT `variants`.`id`,`variants`.`chr`,`variants`.`pos`,`variants`.`ref`,`variants`.`alt` FROM variants WHERE ('&' || `variants`.`ref` || '&' LIKE '%&variant&%') LIMIT 50 OFFSET 0",
+        "SELECT DISTINCT `variants`.`id`,`variants`.`chr`,`variants`.`pos`,`variants`.`ref`,`variants`.`alt` FROM variants WHERE (',' || `variants`.`ref` || ',' LIKE '%,variant,%') LIMIT 50 OFFSET 0",
         "SELECT chr,pos,ref,alt FROM variants WHERE ref HAS 'variant'",
     ),
     # TEST NOT HAS
@@ -537,9 +537,40 @@ QUERY_TESTS = [
             "source": "variants",
             "filters": {"$and": [{"ref": {"$nhas": "variant"}}]},
         },
+        "SELECT DISTINCT `variants`.`id`,`variants`.`chr`,`variants`.`pos`,`variants`.`ref`,`variants`.`alt` FROM variants WHERE (',' || `variants`.`ref` || ',' NOT LIKE '%,variant,%') LIMIT 50 OFFSET 0",
+        "SELECT chr,pos,ref,alt FROM variants WHERE ref !HAS 'variant'",
+    ),
+    (
+        {
+            "fields": ["chr", "pos"],
+            "source": "variants",
+            "filters": {"$and": [{"samples.$any.gt": 1}]},
+        },
+        "SELECT DISTINCT `variants`.`id`,`variants`.`chr`,`variants`.`pos` FROM variants INNER JOIN sample_has_variant `sample_TUMOR` ON `sample_TUMOR`.variant_id = variants.id AND `sample_TUMOR`.sample_id = 1 INNER JOIN sample_has_variant `sample_NORMAL` ON `sample_NORMAL`.variant_id = variants.id AND `sample_NORMAL`.sample_id = 2 WHERE ((`sample_TUMOR`.`gt` = 1 OR `sample_NORMAL`.`gt` = 1)) LIMIT 50 OFFSET 0",
+        "SELECT chr,pos FROM variants WHERE samples[ANY].gt = 1",
+    ),
+    # TEST HA&
+    # Test filters with HA& !
+    (
+        {
+            "fields": ["chr", "pos", "ref", "alt"],
+            "source": "variants",
+            "filters": {"$and": [{"ref": {"$ha&": "variant"}}]},
+        },
+        "SELECT DISTINCT `variants`.`id`,`variants`.`chr`,`variants`.`pos`,`variants`.`ref`,`variants`.`alt` FROM variants WHERE ('&' || `variants`.`ref` || '&' LIKE '%&variant&%') LIMIT 50 OFFSET 0",
+        "SELECT chr,pos,ref,alt FROM variants WHERE ref HAS 'variant'",
+    ),
+    # TEST NOT HA&
+    (
+        {
+            "fields": ["chr", "pos", "ref", "alt"],
+            "source": "variants",
+            "filters": {"$and": [{"ref": {"$nha&": "variant"}}]},
+        },
         "SELECT DISTINCT `variants`.`id`,`variants`.`chr`,`variants`.`pos`,`variants`.`ref`,`variants`.`alt` FROM variants WHERE ('&' || `variants`.`ref` || '&' NOT LIKE '%&variant&%') LIMIT 50 OFFSET 0",
         "SELECT chr,pos,ref,alt FROM variants WHERE ref !HAS 'variant'",
     ),
+    # TEST ANY
     (
         {
             "fields": ["chr", "pos"],


### PR DESCRIPTION
issue #288 
Change HAS operator with standard VCF comma ','
Add HAS operator "HAS (with '&')" in "Filters editor"
Change CuteStyle for Tags
Change Tags separator in variant, sample and sample_variant widgets
Fix Tags add in variant, sample and sample_variant widgets (remove empty tag)