### PR TITLE
Add timestamp created modified on samples variants

### DIFF
--- a/tests/core/test_pedigree.py
+++ b/tests/core/test_pedigree.py
@@ -30,7 +30,7 @@ def test_import_pedfile():
     sql.import_reader(conn, reader)
     sql.import_pedfile(conn, "examples/test.snpeff.pedigree.tfam")
 
-    samples = [dict(row) for row in conn.execute("SELECT * FROM samples")]
+    samples = [dict(row) for row in conn.execute("SELECT id, name, family_id, father_id, mother_id, sex, phenotype, valid, comment, tags FROM samples")]
     print("Found samples:", samples)
 
     expected_first_sample = {


### PR DESCRIPTION
Add "created" and "modified" on tables "samples" and "variants"
Fix INSERT to prevent rowid changes when re-insert a variant or a sample_has_variant :
   replace "INSERT OR REPLACE" by "INSERT ... ON CONFLICT UPDATE ..."
To do after PR #370 