### PR TITLE
Add lock config, locked menu samples/genotypes

### DIFF
--- a/cutevariant/gui/plugins/genotypes/widgets.py
+++ b/cutevariant/gui/plugins/genotypes/widgets.py
@@ -621,6 +621,20 @@ class GenotypesWidget(plugin.PluginWidget):
                 action = cat_menu.addAction(FIcon(0xF012F, item["color"]), item["name"])
                 action.setData(item["number"])
                 action.triggered.connect(self._on_classification_changed)
+            
+            # Locked sample
+            sample_infos=sql.get_sample(self.conn, sample_id = int(sample["sample_id"]))
+            sample_id=sample_infos["id"]
+            if sample_id:
+                classification=sample_infos["classification"]
+                config = Config("classifications")
+                samples_classifications = config.get("samples", [])
+                style = next(i for i in samples_classifications if i["number"] == classification)
+                if "lock" in style:
+                    locked = bool(style["lock"])
+                else:
+                    locked = False
+            cat_menu.setEnabled(not locked)
 
             menu.exec_(event.globalPos())
 

--- a/cutevariant/gui/plugins/samples/widgets.py
+++ b/cutevariant/gui/plugins/samples/widgets.py
@@ -376,8 +376,9 @@ class SamplesWidget(plugin.PluginWidget):
 
         menu.addAction(self.edit_action)
 
-        menu_classification = self._create_classification_menu()
-        menu.addMenu(menu_classification)
+        self.menu_classification = self._create_classification_menu()
+        menu.addMenu(self.menu_classification)
+
         sample = self.model.get_sample(self.view.currentIndex().row())
         if sample:
             classification=sample["classification"]
@@ -386,7 +387,8 @@ class SamplesWidget(plugin.PluginWidget):
                 locked = bool(style["lock"])
             else:
                 locked = False
-        menu_classification.setEnabled(not locked)
+        self.menu_classification.setEnabled(not locked)
+        #self.edit_action.setEnabled(not locked)
 
         menu.addSeparator()
         menu.addAction(self.select_action)

--- a/cutevariant/gui/plugins/samples/widgets.py
+++ b/cutevariant/gui/plugins/samples/widgets.py
@@ -376,7 +376,18 @@ class SamplesWidget(plugin.PluginWidget):
 
         menu.addAction(self.edit_action)
 
-        menu.addMenu(self._create_classification_menu())
+        menu_classification = self._create_classification_menu()
+        menu.addMenu(menu_classification)
+        sample = self.model.get_sample(self.view.currentIndex().row())
+        if sample:
+            classification=sample["classification"]
+            style = next(i for i in self.model.classifications if i["number"] == classification)
+            if "lock" in style:
+                locked = bool(style["lock"])
+            else:
+                locked = False
+        menu_classification.setEnabled(not locked)
+
         menu.addSeparator()
         menu.addAction(self.select_action)
         menu.addAction(self.unselect_action)

--- a/cutevariant/gui/settings.py
+++ b/cutevariant/gui/settings.py
@@ -187,7 +187,7 @@ class ClassificationSettingsWidget(AbstractSettingsWidget):
         super().__init__()
         self.setWindowIcon(FIcon(0xF0133))
 
-        self.widget = ClassificationEditor()
+        self.widget = ClassificationEditor(section=section)
         self.v_layout = QVBoxLayout(self)
         self.v_layout.addWidget(self.widget)
         self.section = section

--- a/cutevariant/gui/widgets/classification_editor.py
+++ b/cutevariant/gui/widgets/classification_editor.py
@@ -11,16 +11,20 @@ from cutevariant.gui.ficon import FIcon
 #     "description": "sdfsdf"
 # }
 
+LOCKED_SECTION=["samples"]
 
 class ClassificationDialog(QDialog):
-    def __init__(self, parent=None):
+    def __init__(self, section=None):
         super().__init__()
+
+        self.section = section
 
         self.number_edit = QLineEdit()
         self.number_edit.setPlaceholderText("Classification id")
         self.number_edit.setValidator(QIntValidator())
         self.name_edit = QLineEdit()
         self.name_edit.setPlaceholderText("Classification Name ...")
+        self.lock_edit = QCheckBox(self.tr("Locked Classification"))
         self.color_edit = QPushButton()
         self.descr_edit = QTextEdit()
         self.descr_edit.setPlaceholderText("Description ...")
@@ -30,6 +34,8 @@ class ClassificationDialog(QDialog):
         form_layout = QVBoxLayout()
         form_layout.addWidget(self.number_edit)
         form_layout.addWidget(self.name_edit)
+        if self.section in LOCKED_SECTION:
+            form_layout.addWidget(self.lock_edit)
         form_layout.addWidget(self.color_edit)
 
         v_layout = QVBoxLayout(self)
@@ -48,6 +54,7 @@ class ClassificationDialog(QDialog):
 
         self.number_edit.setText(str(classification.get("number", 0)))
         self.name_edit.setText(str(classification.get("name", "")))
+        self.lock_edit.setChecked(bool(classification.get("lock", False)))
         self.descr_edit.setPlainText(str(classification.get("description", "")))
         self._set_color(classification.get("color", "black"))
 
@@ -56,6 +63,7 @@ class ClassificationDialog(QDialog):
         classification = {}
         classification["number"] = int(self.number_edit.text())
         classification["name"] = self.name_edit.text()
+        classification["lock"] = self.lock_edit.isChecked() or False
         classification["description"] = self.descr_edit.toPlainText()
         classification["color"] = self.color_edit.text()
         return classification
@@ -173,12 +181,14 @@ class ClassificationEditor(QWidget):
     DESCRIPTION_ROLE = Qt.UserRole + 1
     NUMBER_ROLE = Qt.UserRole + 2
 
-    def __init__(self, parent=None):
+    def __init__(self, section=None):
         super().__init__()
-
+        
         self.model = ClassificationModel()
 
         self.delegate = ClassificationDelegate()
+
+        self.section = section
 
         self.view = QTableView()
         self.view.setSelectionMode(QAbstractItemView.ExtendedSelection)
@@ -216,7 +226,7 @@ class ClassificationEditor(QWidget):
 
     def _on_add_classification(self):
 
-        dialog = ClassificationDialog()
+        dialog = ClassificationDialog(section=self.section)
         if dialog.exec() == QDialog.Accepted:
             classification = dialog.get_classification()
             self.model.add_classification(classification)
@@ -226,7 +236,7 @@ class ClassificationEditor(QWidget):
         current_index = self.view.selectionModel().currentIndex()
         classification = self.model.classification(current_index)
 
-        dialog = ClassificationDialog()
+        dialog = ClassificationDialog(section=self.section)
         dialog.set_classification(classification)
         if dialog.exec() == QDialog.Accepted:
             classification = dialog.get_classification()


### PR DESCRIPTION
Add lock field on classification config in settings (for samples).
Add classification menu locked/disable in "samples" and "genotypes" plugins.

TODO:
- [ ] Lock Edit dialog on "genotypes" plugin
- [ ] Lock Edit dialog fields (tag, comment, family, phenotype) on "samples" plugin
- [ ] Lock Edit dialog and genotype classification menu on "Variant view" plugin (when done/merge)