### PR TITLE
fix import tags, import/project wizards, and tests

### DIFF
--- a/cutevariant/gui/widgets/import_widget.py
+++ b/cutevariant/gui/widgets/import_widget.py
@@ -42,6 +42,7 @@ from PySide6.QtWidgets import (
 import sqlite3
 import time
 import tempfile
+import os
 from cutevariant.gui.ficon import FIcon
 from cutevariant.core.reader.vcfreader import VcfReader
 from cutevariant.core.reader import PedReader
@@ -307,6 +308,7 @@ class VcfImportWidget(QWidget):
         self.file_path_edit.setToolTip(
             self.tr("Path to a supported input file. (e.g: VCF  file ) ")
         )
+        self.import_id = QLineEdit()
         self.lock_button = QPushButton(self.tr("Edit"))
         self.lock_button.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Preferred)
         self.lock_button.setCheckable(True)
@@ -328,6 +330,8 @@ class VcfImportWidget(QWidget):
         # top formular
         h_layout = QHBoxLayout()
         h_layout.addWidget(self.file_path_edit)
+        h3_layout = QHBoxLayout()
+        h3_layout.addWidget(self.import_id)
         h_layout.addWidget(self.button)
         h2_layout = QHBoxLayout()
         h2_layout.addWidget(self.annotation_box)
@@ -337,6 +341,7 @@ class VcfImportWidget(QWidget):
         self.v_layout = QFormLayout(self.file_group)
         self.v_layout.addRow("Input File", h_layout)
         self.v_layout.addRow("Annotation", h2_layout)
+        self.v_layout.addRow("Import ID", h3_layout)
 
         # Create content
         self.tabwidget.addTab(self.fields_widget, "Fields")
@@ -376,6 +381,7 @@ class VcfImportWidget(QWidget):
         if filepath:
             # Display and save directory
             self.file_path_edit.setText(filepath)
+            self.import_id.setText(os.path.basename(filepath))
 
             if "vcf" in filepath:
                 # TODO: detect annotations on other tyes of files...
@@ -390,6 +396,9 @@ class VcfImportWidget(QWidget):
 
     def filename(self):
         return self.file_path_edit.text()
+
+    def get_import_id(self):
+        return self.import_id.text()
 
     def pedfile(self):
         _, filename = tempfile.mkstemp()
@@ -491,6 +500,8 @@ class ImportThread(QThread):
         self.db_filename = None
         # File top open
         self.filename = None
+        # Import ID
+        self.import_id = None
         # pedfile
         self.pedfile = None
         # Ignored fields
@@ -535,24 +546,18 @@ class ImportThread(QThread):
             # Import VARIANT FILE
             self.finished_status.emit(False)
             self.emit_progress("**Import Variants**")
+            import_id=self.import_id
             with create_reader(self.filename, self.annotation_parser) as reader:
                 self._reader = reader
                 sql.import_reader(
                     self.conn,
                     reader,
                     pedfile=self.pedfile,
+                    import_id=import_id,
                     ignored_fields=self.ignored_fields,
                     indexed_fields=self.indexed_fields,
                     progress_callback=self.emit_progress,
                 )
-
-            # Update Index
-            # sql.create_indexes(
-            #     self.conn,
-            #     self.indexed_variant_fields,
-            #     self.indexed_annotation_fields,
-            #     self.indexed_sample_fields,
-            # )
 
             self.conn.close()
 
@@ -609,6 +614,7 @@ class VcfImportDialog(QDialog):
 
         self.progress_dialog.reset()
         self.thread.filename = self.widget.filename()
+        self.thread.import_id = self.widget.get_import_id()
 
         # create pedfile
         self.thread.pedfile = self.widget.pedfile()

--- a/cutevariant/gui/widgets/project_wizard.py
+++ b/cutevariant/gui/widgets/project_wizard.py
@@ -149,6 +149,7 @@ class ImportPage(QWizardPage):
         self.thread.db_filename = self.wizard().page(0).db_filename()
         self.thread.filename = self.wizard().page(1).filename()
         self.thread.pedfile = self.wizard().page(1).pedfile()
+        self.thread.import_id = self.wizard().page(1).widget.get_import_id()
         self.thread.ignored_fields = self.wizard().page(1).widget.get_ignored_fields()
         self.thread.indexed_fields = self.wizard().page(1).widget.get_indexed_fields()
         self.thread.start()

--- a/tests/core/test_pedigree.py
+++ b/tests/core/test_pedigree.py
@@ -29,6 +29,9 @@ def test_import_pedfile():
     sql.import_pedfile(conn, "examples/test.snpeff.pedigree.tfam")
 
     samples = [dict(row) for row in conn.execute("SELECT * FROM samples")]
+    # remove tags field due to changing date value (not tracable)
+    for sample in samples:
+        sample.pop("tags")
     print("Found samples:", samples)
 
     expected_first_sample = {
@@ -41,7 +44,6 @@ def test_import_pedfile():
         "phenotype": 1,
         "classification": 0,
         "comment": "",
-        "tags": "",
     }
     expected_second_sample = {
         "id": 2,
@@ -53,7 +55,6 @@ def test_import_pedfile():
         "phenotype": 2,
         "classification": 0,
         "comment": "",
-        "tags": "",
     }
 
     # Third sample is not conform


### PR DESCRIPTION
### Creation of import tags
- **importVCF**: name of the VCF file (e.g. "importVCF#snpEff.vcf")
- **importDATE**: date of the import (e.g. "importDATE#20220601-140356")
- **importID**: ID of the import (e.g. "importVCF#snpEff.vcf" by default in wizard, "importID#20220601-140356" by default in insert_samples function, "importID#RUNX" if user change the import ID in wizard)

### Change project/import wizards
- add "import ID" field that can be changed by user (default: name of the VCF file)

### Change test files
