### PR TITLE
Fix HAS operator separator from & to constant

### DIFF
--- a/cutevariant/constants.py
+++ b/cutevariant/constants.py
@@ -51,6 +51,9 @@ OPERATORS_SQL_2_PY = {
     "OR": "$or",
 }
 
+# OPERATOR HAS
+HAS_OPERATOR=","
+
 # Phenotype
 PHENOTYPE_DESC = {2: "Affected", 1: "Unaffected"}
 

--- a/cutevariant/core/querybuilder.py
+++ b/cutevariant/core/querybuilder.py
@@ -30,6 +30,8 @@ from ast import literal_eval
 # Custom imports
 from cutevariant.core import sql
 
+import cutevariant.constants as cst
+
 
 from cutevariant import LOGGER
 
@@ -350,11 +352,9 @@ def condition_to_sql(item: dict, samples=None) -> str:
             value = f"%{value}%"
 
     if "HAS" in sql_operator:
-        field = f"'&' || {field} || '&'"
+        field = f"'{cst.HAS_OPERATOR}' || {field} || '{cst.HAS_OPERATOR}'"
         sql_operator = "LIKE" if sql_operator == "HAS" else "NOT LIKE"
-        value = f"%&{value}&%"
-
-        # WHERE '&' || consequence || '&' LIKE "%&missense_variant&%"
+        value = f"%{cst.HAS_OPERATOR}{value}{cst.HAS_OPERATOR}%"
 
     # Cast value
     if isinstance(value, str):

--- a/cutevariant/gui/formatters/cutestyle.py
+++ b/cutevariant/gui/formatters/cutestyle.py
@@ -121,7 +121,7 @@ class CutestyleFormatter(Formatter):
                 return {"text": value}
 
         if field == "ann.consequence":
-            values = str(value).split("&")
+            values = str(value).split(cst.HAS_OPERATOR)
             font = QFont()
             metrics = QFontMetrics(font)
             x = 0

--- a/tests/core/test_querybuilder.py
+++ b/tests/core/test_querybuilder.py
@@ -2,6 +2,7 @@ import pytest
 from cutevariant.core import querybuilder, sql
 from tests.utils import create_conn
 
+import cutevariant.constants as cst
 
 def test_order_by():
     conn = create_conn()
@@ -567,7 +568,7 @@ QUERY_TESTS = [
             "source": "variants",
             "filters": {"$and": [{"ref": {"$has": "variant"}}]},
         },
-        "SELECT DISTINCT `variants`.`id`,`variants`.`chr`,`variants`.`pos`,`variants`.`ref`,`variants`.`alt` FROM variants WHERE ('&' || `variants`.`ref` || '&' LIKE '%&variant&%') LIMIT 50 OFFSET 0",
+        f"SELECT DISTINCT `variants`.`id`,`variants`.`chr`,`variants`.`pos`,`variants`.`ref`,`variants`.`alt` FROM variants WHERE ('{cst.HAS_OPERATOR}' || `variants`.`ref` || '{cst.HAS_OPERATOR}' LIKE '%{cst.HAS_OPERATOR}variant{cst.HAS_OPERATOR}%') LIMIT 50 OFFSET 0",
         "SELECT chr,pos,ref,alt FROM variants WHERE ref HAS 'variant'",
     ),
     # TEST NOT HAS
@@ -577,7 +578,7 @@ QUERY_TESTS = [
             "source": "variants",
             "filters": {"$and": [{"ref": {"$nhas": "variant"}}]},
         },
-        "SELECT DISTINCT `variants`.`id`,`variants`.`chr`,`variants`.`pos`,`variants`.`ref`,`variants`.`alt` FROM variants WHERE ('&' || `variants`.`ref` || '&' NOT LIKE '%&variant&%') LIMIT 50 OFFSET 0",
+        f"SELECT DISTINCT `variants`.`id`,`variants`.`chr`,`variants`.`pos`,`variants`.`ref`,`variants`.`alt` FROM variants WHERE ('{cst.HAS_OPERATOR}' || `variants`.`ref` || '{cst.HAS_OPERATOR}' NOT LIKE '%{cst.HAS_OPERATOR}variant{cst.HAS_OPERATOR}%') LIMIT 50 OFFSET 0",
         "SELECT chr,pos,ref,alt FROM variants WHERE ref !HAS 'variant'",
     ),
     (


### PR DESCRIPTION
Fix HAS operator separator from & to constant
Default separator is comma (",") as described in VCF format recommandations
 