### PR TITLE
Fix tooltip on vertical header

### DIFF
--- a/cutevariant/gui/plugins/genotypes/widgets.py
+++ b/cutevariant/gui/plugins/genotypes/widgets.py
@@ -230,10 +230,11 @@ class GenotypeModel(QAbstractTableModel):
             if section < len(self._headers):
                 return self._headers[section]
 
-        # if orientation == Qt.Vertical and role == Qt.DisplayRole:
-        #     item = self.get_genotype(section)
-        #     if "classification" in item:
-        #         return item["classification"]
+        # vertical header
+        if role == Qt.ToolTipRole  and orientation == Qt.Vertical:
+            genotype = self.get_genotype(section)
+            genotype_tooltip = toolTip.genotype_tooltip(data=genotype, conn=self.conn)
+            return genotype_tooltip
 
         return None
 

--- a/cutevariant/gui/plugins/genotypes/widgets.py
+++ b/cutevariant/gui/plugins/genotypes/widgets.py
@@ -30,7 +30,7 @@ from cutevariant.gui.widgets import (
     PresetAction,
 )
 
-from cutevariant.gui import tooltip
+from cutevariant.gui import tooltip as toolTip
 from cutevariant import LOGGER
 from cutevariant.gui.sql_thread import SqlThread
 
@@ -221,9 +221,8 @@ class GenotypeModel(QAbstractTableModel):
     def get_tooltip(self, row: int):
         """Return all samples info as a formatted text"""
 
-        return tooltip.genotype_tooltip(data=self.get_genotype(row), conn=self.conn)
+        return toolTip.genotype_tooltip(data=self.get_genotype(row), conn=self.conn)
 
-        # return message
 
     def headerData(self, section: int, orientation: Qt.Orientation, role: int):
 

--- a/cutevariant/gui/plugins/samples/widgets.py
+++ b/cutevariant/gui/plugins/samples/widgets.py
@@ -65,6 +65,12 @@ class SampleModel(QAbstractTableModel):
         if orientation == Qt.Horizontal and role == Qt.DisplayRole and section == 0:
             return self.tr("Samples")
 
+        # vertical header
+        if role == Qt.ToolTipRole  and orientation == Qt.Vertical:
+            sample = self._samples[section]
+            sample_tooltip = toolTip.sample_tooltip(data=sample, conn=self.conn)
+            return sample_tooltip
+
     def data(self, index: QModelIndex, role: int = Qt.DisplayRole):
 
         col = index.column()

--- a/cutevariant/gui/plugins/samples/widgets.py
+++ b/cutevariant/gui/plugins/samples/widgets.py
@@ -21,7 +21,7 @@ from cutevariant.gui.widgets import (
     SamplesEditor,
 )
 
-from cutevariant.gui import style as Style
+from cutevariant.gui import tooltip as toolTip
 
 # from gui.style import SAMPLE_CLASSIFICATION
 
@@ -123,52 +123,7 @@ class SampleModel(QAbstractTableModel):
             sample = self._samples[index.row()]
 
             if col == SampleModel.COMMENT_COLUMN:
-                config = Config("classifications")
-                genotype_classifications = config.get("genotypes", [])
-                sample_id = sample["id"]
-                sample_name = sample["name"]
-                sample_nb_genotype_by_classification = (
-                    sql.get_sample_nb_genotype_by_classification(self.conn, sample_id)
-                )
-                nb_validated_genotype = 0
-                nb_validation_genotype_message = ""
-                for classification in sample_nb_genotype_by_classification:
-                    nb_validation_genotype_text = ""
-                    nb_validation_genotype_color = ""
-                    nb_genotype_by_classification = (
-                        sample_nb_genotype_by_classification[classification]
-                    )
-                    if classification > 0:
-                        nb_validated_genotype += nb_genotype_by_classification
-                    style = None
-                    for i in genotype_classifications:
-                        if i["number"] == classification:
-                            style = i
-                    if style:
-                        if "name" in style:
-                            nb_validation_genotype_text += style["name"]
-                            if "description" in style:
-                                nb_validation_genotype_text += (
-                                    f" (" + style["description"].strip() + ")"
-                                )
-                        if "color" in style:
-                            nb_validation_genotype_color = style["color"]
-                    nb_validation_genotype_message += f"<tr><td style='color:{nb_validation_genotype_color}' align='right'>{nb_genotype_by_classification}</td><td width='10'></td><td>{nb_validation_genotype_text}</td></tr>"
-                sample_comment = f"Comment on sample <b>{sample_name}</b><hr>"
-                comment = sample["comment"].replace("\n", "<br>")
-                if comment:
-                    sample_comment += "" + comment + "<br>"
-                else:
-                    sample_comment += "<i>No comment</i><br>"
-                if nb_validation_genotype_message:
-                    sample_comment += f"""
-                        <hr>
-                        Genotypes classification
-                        <table>
-                            {nb_validation_genotype_message}
-                        </table>
-                    """
-
+                sample_comment = toolTip.sample_tooltip(data=sample, conn=self.conn)
                 return sample_comment
 
             if col == SampleModel.NAME_COLUMN:
@@ -183,7 +138,7 @@ class SampleModel(QAbstractTableModel):
     def get_tooltip(self, row: int) -> str:
         """Return all samples info as a formatted text"""
 
-        tooltip = Style.sample_tooltip(data=self._samples[row], conn=self.conn)
+        tooltip = toolTip.sample_tooltip(data=self._samples[row], conn=self.conn)
         return tooltip
 
         # info = ""

--- a/cutevariant/gui/plugins/variant_view/widgets.py
+++ b/cutevariant/gui/plugins/variant_view/widgets.py
@@ -47,6 +47,7 @@ import cutevariant.constants as cst
 import cutevariant.commons as cm
 from cutevariant.core.querybuilder import filters_to_flat
 
+from cutevariant.gui import tooltip as toolTip
 
 class VariantVerticalHeader(QHeaderView):
     def __init__(self, parent=None):
@@ -382,23 +383,12 @@ class VariantModel(QAbstractTableModel):
                 font.setBold(col_filtered)
                 return font
 
-        # if orientation == Qt.Vertical:
-        #     if role == Qt.DecorationRole:
-
-        #         pix = QPixmap(32, 32)
-        #         pix.fill(QColor("white"))
-        #         # pix.fill(Qt.transparent)
-        #         painter = QPainter()
-        #         painter.begin(pix)
-        #         pen = QPen(QColor("red"))
-        #         pen.setWidth(20)
-        #         painter.setPen(pen)
-        #         painter.drawLine(-2, -10, -2, 30)
-        #         painter.drawPixmap(0, 0, FIcon(0xF0ACD).pixmap(40, 40))
-        #         painter.end()
-        #         fav = self.variants[section]["favorite"]
-        #         return QIcon(pix)
-        #         # return QIcon(FIcon(0xF0ACD)) if fav else QIcon(FIcon(0xF0ACE))
+        # vertical header
+        if role == Qt.ToolTipRole  and orientation == Qt.Vertical:
+            variant = self.variant(section)
+            variant = variant | dict(sql.get_variant(conn=self.conn, variant_id=variant["id"], with_annotations=True, with_samples=True))
+            variant_tooltip = toolTip.variant_tooltip(data=variant, conn=self.conn, fields=self.fields)
+            return variant_tooltip
 
     def update_variant(self, row: int, variant: dict):
         """Update a variant at the given row with given content

--- a/cutevariant/gui/tooltip.py
+++ b/cutevariant/gui/tooltip.py
@@ -5,6 +5,7 @@ Code needs improvement . Avoid multiple embbeded if
 import sqlite3
 
 from cutevariant.config import Config
+from cutevariant.gui import style as Style
 from cutevariant.core import sql
 from cutevariant import constants as cst
 
@@ -79,7 +80,7 @@ def genotype_tooltip(data: dict, conn: sqlite3.Connection):
 
     # tag genotype
     if genotype["gt"]:
-        genotype_text = GENOTYPE.get(genotype["gt"], "Unknown")["name"]
+        genotype_text = Style.GENOTYPE.get(genotype["gt"], "Unknown")["name"]
     else:
         genotype_text = "<i>no tag</i>"
     genotype["genotype_text"] = genotype_text

--- a/cutevariant/gui/widgets/sample_widget.py
+++ b/cutevariant/gui/widgets/sample_widget.py
@@ -21,7 +21,7 @@ from cutevariant import gui
 import cutevariant.constants as cst
 from cutevariant.gui.formatters.cutestyle import CutestyleFormatter
 
-from cutevariant.gui import style as Style
+from cutevariant.gui import tooltip as toolTip
 
 class AbstractSectionWidget(QWidget):
     def __init__(self, parent: QWidget = None):
@@ -376,7 +376,7 @@ class OccurenceModel(QAbstractTableModel):
             TYPE: Description
         """
         
-        tooltip = Style.genotype_tooltip(data = self.item(row), conn = self._parent.conn)
+        tooltip = toolTip.genotype_tooltip(data = self.item(row), conn = self._parent.conn)
         return tooltip
 
 

--- a/cutevariant/gui/widgets/variant_widget.py
+++ b/cutevariant/gui/widgets/variant_widget.py
@@ -24,7 +24,7 @@ from cutevariant.gui.ficon import FIcon
 from cutevariant.gui.formatters.cutestyle import CutestyleFormatter
 from cutevariant import constants as cst
 from cutevariant import commons as cm
-from cutevariant.gui import style as Style
+from cutevariant.gui import tooltip as toolTip
 
 # from cutevariant.gui.formatters.cutestyle import CutestyleFormatter
 
@@ -357,7 +357,7 @@ class OccurenceModel(QAbstractTableModel):
             TYPE: Description
         """
 
-        tooltip = Style.genotype_tooltip(data = self.item(row), conn = self._parent.conn)
+        tooltip = toolTip.genotype_tooltip(data = self.item(row), conn = self._parent.conn)
         return tooltip
 
 


### PR DESCRIPTION
ToolTips on vertical headers
Add variant toolTip on "Variant view" 
Add variant toolTip on genotype toolTip
Add HAS_SEPARATOR on toolTip field to split infos

![toolTips](https://user-images.githubusercontent.com/40463532/172208976-60162e14-6713-4265-b312-bcdbe982c323.gif)

