### PR TITLE
fix checked icon for classified genotype by sample

### DIFF
--- a/cutevariant/core/sql.py
+++ b/cutevariant/core/sql.py
@@ -2941,6 +2941,16 @@ def get_sample_nb_genotype_by_classification(conn, sample_id: int):
         )
     )
 
+def get_if_sample_has_classified_genotypes(conn, sample_id: int):
+    """Get if sample id has classificed genotype (>0)"""
+    conn.row_factory = sqlite3.Row
+    res = conn.execute(
+            f"SELECT 1 as variant FROM genotypes WHERE genotypes.sample_id = '{sample_id}' AND classification > 0 LIMIT 1"
+        ).fetchone()
+    if res:
+        return True
+    else:
+        return False
 
 def get_genotypes(conn, variant_id: int, fields: List[str] = None, samples: List[str] = None):
     """Get samples annotation for a specific variant using different filters

--- a/cutevariant/gui/plugins/samples/widgets.py
+++ b/cutevariant/gui/plugins/samples/widgets.py
@@ -106,19 +106,11 @@ class SampleModel(QAbstractTableModel):
 
             if col == SampleModel.COMMENT_COLUMN:
                 sample = self._samples[index.row()]
-                nb_validated_genotype = 0
-                # code remove because of lag
-                # sample_id = sample["id"]
-                # sample_nb_genotype_by_classification = (
-                #     sql.get_sample_nb_genotype_by_classification(self.conn, sample_id)
-                # )
-                # for classification in sample_nb_genotype_by_classification:
-                #     nb_genotype_by_classification = (
-                #         sample_nb_genotype_by_classification[classification]
-                #     )
-                #     if classification > 0:
-                #         nb_validated_genotype += nb_genotype_by_classification
-                if nb_validated_genotype > 0:
+                sample_id = sample["id"]
+                sample_has_classified_genotypes = (
+                    sql.get_if_sample_has_classified_genotypes(self.conn, sample_id)
+                )
+                if sample_has_classified_genotypes:
                     return QIcon(FIcon(0xF017F, color))
                 if sample["comment"]:
                     return QIcon(FIcon(0xF017A, color))

--- a/cutevariant/gui/plugins/samples/widgets.py
+++ b/cutevariant/gui/plugins/samples/widgets.py
@@ -106,11 +106,9 @@ class SampleModel(QAbstractTableModel):
 
             if col == SampleModel.COMMENT_COLUMN:
                 sample = self._samples[index.row()]
-                sample_id = sample["id"]
-                sample_has_classified_genotypes = (
-                    sql.get_if_sample_has_classified_genotypes(self.conn, sample_id)
-                )
-                if sample_has_classified_genotypes:
+                if sql.get_if_sample_has_classified_genotypes(
+                    self.conn, sample["id"]
+                    ):
                     return QIcon(FIcon(0xF017F, color))
                 if sample["comment"]:
                     return QIcon(FIcon(0xF017A, color))

--- a/cutevariant/gui/plugins/samples/widgets.py
+++ b/cutevariant/gui/plugins/samples/widgets.py
@@ -90,27 +90,27 @@ class SampleModel(QAbstractTableModel):
                 sex = sample.get("sex", None)
                 if sex == 1:
                     return QIcon(FIcon(0xF029D))
-                if sex == 2:
+                elif sex == 2:
                     return QIcon(FIcon(0xF029C))
-                if sex == 0:
+                elif sex == 0:
                     return QIcon(FIcon(0xF029E, color_alpha))
 
-            if col == SampleModel.PHENOTYPE_COLUMN:
+            elif col == SampleModel.PHENOTYPE_COLUMN:
                 phenotype = sample.get("phenotype")
                 if phenotype == 2:
                     return QIcon(FIcon(0xF08C9, color))
-                if phenotype == 1:
+                elif phenotype == 1:
                     return QIcon(FIcon(0xF05DD, color))
                 else:
                     return QIcon(FIcon(0xF001A, color_alpha))
 
-            if col == SampleModel.COMMENT_COLUMN:
+            elif col == SampleModel.COMMENT_COLUMN:
                 sample = self._samples[index.row()]
                 if sql.get_if_sample_has_classified_genotypes(
                     self.conn, sample["id"]
                     ):
                     return QIcon(FIcon(0xF017F, color))
-                if sample["comment"]:
+                elif sample["comment"]:
                     return QIcon(FIcon(0xF017A, color))
                 else:
                     return QIcon(FIcon(0xF017A, color_alpha))
@@ -123,13 +123,13 @@ class SampleModel(QAbstractTableModel):
                 sample_comment = toolTip.sample_tooltip(data=sample, conn=self.conn)
                 return sample_comment
 
-            if col == SampleModel.NAME_COLUMN:
+            elif col == SampleModel.NAME_COLUMN:
                 return self.get_tooltip(index.row())
 
-            if col == SampleModel.PHENOTYPE_COLUMN:
+            elif col == SampleModel.PHENOTYPE_COLUMN:
                 return cst.PHENOTYPE_DESC.get(int(sample["phenotype"]), "Unknown")
 
-            if col == SampleModel.SEX_COLUMN:
+            elif col == SampleModel.SEX_COLUMN:
                 return cst.SEX_DESC.get(int(sample["sex"]), "Unknown")
 
     def get_tooltip(self, row: int) -> str:


### PR DESCRIPTION
Because it's a shame to not have this icon on sample, to quickly see if samples has already classified/validated genotype/variant, I suggest this fix!
SQL query is about 10ms, instead of 170ms before, just to check if there is at least 1 genotype validated. To see the number of genotypes and variants that are validated, go to "Sample Editor".

See sample '192975' with at least one validated genotype/variant:

<img width="374" alt="image" src="https://user-images.githubusercontent.com/40463532/172428346-198b84e0-8066-48ea-b461-53f1b4977732.png">

