### PR TITLE
fix tags by simplifying text edition

### DIFF
--- a/cutevariant/gui/widgets/sample_variant_widget.py
+++ b/cutevariant/gui/widgets/sample_variant_widget.py
@@ -96,7 +96,7 @@ class EvaluationSectionWidget(AbstractSectionWidget):
     def get_genotype(self) -> dict:
         genotype = {
             "classification": self.class_combo.currentData(),
-            "tags": self.TAG_SEPARATOR.join([tag.strip() for tag in self.tag_edit.text().split(",") if tag.strip()]),
+            "tags": self.TAG_SEPARATOR.join([tag.strip() for tag in self.tag_edit.text().replace("\n",self.TAG_SEPARATOR).replace(" ",self.TAG_SEPARATOR).split(self.TAG_SEPARATOR) if tag]),
             "comment": self.comment.toPlainText(),
         }
 
@@ -106,7 +106,7 @@ class EvaluationSectionWidget(AbstractSectionWidget):
 
         # Load tags
         if "tags" in genotype:
-            self.tag_edit.setText(",".join(genotype["tags"].split(self.TAG_SEPARATOR)))
+            self.tag_edit.setText("\n".join(genotype["tags"].replace("\n",self.TAG_SEPARATOR).replace(" ",self.TAG_SEPARATOR).split(self.TAG_SEPARATOR)))
 
         # Load comment
         if "comment" in genotype:

--- a/cutevariant/gui/widgets/sample_widget.py
+++ b/cutevariant/gui/widgets/sample_widget.py
@@ -111,7 +111,7 @@ class EvaluationSectionWidget(AbstractSectionWidget):
         sample = {
             "name": self.name_label.text(),
             "classification": self.class_combo.currentData(),
-            "tags": self.TAG_SEPARATOR.join([tag.strip() for tag in self.tag_edit.text().split(",") if tag.strip()]),
+            "tags": self.TAG_SEPARATOR.join([tag.strip() for tag in self.tag_edit.text().replace("\n",self.TAG_SEPARATOR).replace(" ",self.TAG_SEPARATOR).split(self.TAG_SEPARATOR) if tag]),
             "comment": self.comment.toPlainText(),
         }
 
@@ -125,7 +125,7 @@ class EvaluationSectionWidget(AbstractSectionWidget):
 
         # Load tags
         if "tags" in sample:
-            self.tag_edit.setText(",".join(sample["tags"].split(self.TAG_SEPARATOR)))
+            self.tag_edit.setText("\n".join(sample["tags"].replace("\n",self.TAG_SEPARATOR).replace(" ",self.TAG_SEPARATOR).split(self.TAG_SEPARATOR)))
 
         # Load comment
         if "comment" in sample:

--- a/cutevariant/gui/widgets/tagedit.py
+++ b/cutevariant/gui/widgets/tagedit.py
@@ -16,8 +16,9 @@ class TagEditSyntaxHighlighter(QSyntaxHighlighter):
         f.setBackground(QBrush(QColor("#D5E9F5")))
         f.setForeground(QBrush(QColor("D5E9F5").darker().darker()))
         f.setFontWeight(QFont.Bold)
-        for match in re.finditer(r"([^,]+)", text):
+        for match in re.finditer(r"([^, ]+)", text):
             start, end = match.span()
+            # TODO: find color from preset tags
             self.setFormat(start, (end - start), f)
 
 
@@ -34,7 +35,7 @@ class TagEdit(QTextEdit):
 
         metric = QFontMetrics(self.font())
 
-        self.setFixedHeight(metric.height() + 10)
+        self.setFixedHeight(metric.height() + 60)
 
     def text(self):
         return self.toPlainText()

--- a/cutevariant/gui/widgets/variant_widget.py
+++ b/cutevariant/gui/widgets/variant_widget.py
@@ -96,7 +96,7 @@ class EvaluationSectionWidget(AbstractSectionWidget):
             #"id": self.variant_label.text(),
             "favorite": self.favorite.isChecked(),
             "classification": self.class_combo.currentData(),
-            "tags": self.TAG_SEPARATOR.join([tag for tag in self.tag_edit.text().split(",") if tag]),
+            "tags": self.TAG_SEPARATOR.join([tag.strip() for tag in self.tag_edit.text().replace("\n",self.TAG_SEPARATOR).replace(" ",self.TAG_SEPARATOR).split(self.TAG_SEPARATOR) if tag]),
             "comment": self.comment.toPlainText(),
         }
 
@@ -132,7 +132,7 @@ class EvaluationSectionWidget(AbstractSectionWidget):
 
         # Load tags
         if "tags" in variant:
-            self.tag_edit.setText(",".join(variant["tags"].split(self.TAG_SEPARATOR)))
+            self.tag_edit.setText("\n".join(variant["tags"].replace("\n",self.TAG_SEPARATOR).replace(" ",self.TAG_SEPARATOR).split(self.TAG_SEPARATOR)))
 
         # Load comment
         if "comment" in variant:


### PR DESCRIPTION
Fix tag edition
Simplifying text box edition
Separator in textBox: space, comma and breakline
Store in database: HAS_OPERATOR (comma)

![tag_edit](https://user-images.githubusercontent.com/40463532/172469895-9a4c39f0-eb67-44c9-9b12-654cd748345c.gif)

