### PR TITLE
Fix Genotype Editor, lock feature, some bugs

### DIFF
--- a/cutevariant/gui/plugins/genotypes/widgets.py
+++ b/cutevariant/gui/plugins/genotypes/widgets.py
@@ -635,21 +635,9 @@ class GenotypesWidget(plugin.PluginWidget):
 
         # Add section Sample
         sample_name = genotype.get("name", "unknown")
-        menu.addAction(
-            FIcon(0xF0013),
-            sample_name,
-            functools.partial(QApplication.instance().clipboard().setText, sample_name),
-        )
 
         # Add section Variant
         variant_name = self.find_variant_name(troncate=True)
-        menu.addAction(
-            FIcon(0xF014C),
-            variant_name,
-            functools.partial(QApplication.instance().clipboard().setText, variant_name),
-        )
-
-        menu.addSeparator()
 
         # Validation
         if genotype["gt"]:
@@ -666,7 +654,9 @@ class GenotypesWidget(plugin.PluginWidget):
                 validation_menu_title = "Classification"
 
             menu.addAction(
-                "Edit Genotype", self._show_sample_variant_dialog
+                FIcon(0xF064F),
+                f"Edit Genotype '{sample_name}' - '{variant_name}'",
+                self._show_sample_variant_dialog
             )
 
             cat_menu = menu.addMenu(validation_menu_title)

--- a/cutevariant/gui/plugins/genotypes/widgets.py
+++ b/cutevariant/gui/plugins/genotypes/widgets.py
@@ -3,6 +3,7 @@
 from dataclasses import replace
 import typing
 from functools import cmp_to_key, partial
+import functools
 import time
 import copy
 import re
@@ -626,24 +627,50 @@ class GenotypesWidget(plugin.PluginWidget):
 
     def contextMenuEvent(self, event: QContextMenuEvent):
 
+        row = self.view.selectionModel().currentIndex().row()
+        
+        genotype = self.model.get_genotype(row)
+
         menu = QMenu(self)
 
-        # variant name
-        variant_name = self.find_variant_name(troncate=True)
+        # Add section Sample
+        sample_name = genotype.get("name", "unknown")
+        menu.addAction(
+            FIcon(0xF0013),
+            sample_name,
+            functools.partial(QApplication.instance().clipboard().setText, sample_name),
+        )
 
-        # Add section
-        menu.addSection("Variant " + variant_name)
+        # Add section Variant
+        variant_name = self.find_variant_name(troncate=True)
+        menu.addAction(
+            FIcon(0xF014C),
+            variant_name,
+            functools.partial(QApplication.instance().clipboard().setText, variant_name),
+        )
+
+        menu.addSeparator()
 
         # Validation
-        row = self.view.selectionModel().currentIndex().row()
-        sample = self.model.get_genotype(row)
+        if genotype["gt"]:
 
-        if sample["gt"]:
+            # find sample lock/unlock
+            sample = sql.get_sample(self.conn, genotype["sample_id"])
+            sample_classification = sample.get("classification", 0)
+
+            if style.SAMPLE_CLASSIFICATION[sample_classification].get("lock"):
+                validation_menu_enable = False
+                validation_menu_title = "Classification (locked)"
+            else:
+                validation_menu_enable = True
+                validation_menu_title = "Classification"
+
             menu.addAction(
-                "Edit Genotype classification...", self._show_sample_variant_dialog
+                "Edit Genotype", self._show_sample_variant_dialog
             )
 
-            cat_menu = menu.addMenu("Classifications")
+            cat_menu = menu.addMenu(validation_menu_title)
+            cat_menu.setEnabled(validation_menu_enable)
 
             for item in self.model.classifications:
 

--- a/cutevariant/gui/plugins/samples/widgets.py
+++ b/cutevariant/gui/plugins/samples/widgets.py
@@ -390,10 +390,6 @@ class SamplesWidget(plugin.PluginWidget):
             FIcon(0xF120A), "Clear sample(s)", self.on_clear_samples
         )
 
-        self.edit_action = self.tool_bar.addAction(
-            FIcon(0xF0FFB), "Edit Sample", self.on_edit
-        )
-
         spacer = QWidget()
         spacer.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
         self.tool_bar.addWidget(spacer)
@@ -420,20 +416,20 @@ class SamplesWidget(plugin.PluginWidget):
 
         genotype_action.setToolTip(self.tr("Add genotypes as fields from all samples"))
 
-        self.select_action = QAction(FIcon(0xF0349), "Select variants for the sample")
+        self.select_action = QAction(FIcon(0xF0349), "Select variants")
         self.select_action.triggered.connect(self.on_show_variant)
 
         self.create_filter_action = QAction(
-            FIcon(0xF0EF1), "Create filters for the sample"
+            FIcon(0xF0EF1), "Create filters"
         )
         self.create_filter_action.triggered.connect(self.on_create_filter)
 
         self.clear_filter_action = QAction(
-            FIcon(0xF0234), "Clear all filters for the sample"
+            FIcon(0xF0234), "Clear all filters"
         )
         self.clear_filter_action.triggered.connect(self.on_clear_filters)
 
-        self.source_action = QAction(FIcon(0xF0A75), "Create a source for the sample")
+        self.source_action = QAction(FIcon(0xF0A75), "Create a source")
         self.source_action.triggered.connect(self.on_create_samples_source)
         self.genotype_action = QAction(FIcon(0xF0B38), "Add genotypes from all samples")
         self.genotype_action.triggered.connect(self.on_add_genotypes)
@@ -448,14 +444,11 @@ class SamplesWidget(plugin.PluginWidget):
 
         menu = QMenu(self)
 
-        menu.addAction(
-            FIcon(0xF0013), # 0xF0013
-            sample_name,
-            functools.partial(QApplication.instance().clipboard().setText, sample_name),
+        self.edit_action = self.tool_bar.addAction(
+            FIcon(0xF064F),
+            f"Edit Sample '{sample_name}'",
+            self.on_edit
         )
-
-        menu.addSeparator()
-
         menu.addAction(self.edit_action)
 
         menu.addMenu(self._create_classification_menu(sample))

--- a/cutevariant/gui/plugins/variant_view/widgets.py
+++ b/cutevariant/gui/plugins/variant_view/widgets.py
@@ -1316,16 +1316,8 @@ class VariantView(QWidget):
         variant_name = formatted_variant.format(**full_variant)
 
         menu.addAction(
-            FIcon(0xF014C),
-            variant_name,
-            functools.partial(QApplication.instance().clipboard().setText, variant_name),
-        )
-
-        menu.addSeparator()
-
-        menu.addAction(
-            FIcon(0xF14E6),
-            "Edit Variant",
+            FIcon(0xF064F),
+            f"Edit Variant '{variant_name}'",
             self._show_variant_dialog,
         )
 

--- a/cutevariant/gui/plugins/variant_view/widgets.py
+++ b/cutevariant/gui/plugins/variant_view/widgets.py
@@ -1740,12 +1740,12 @@ class VariantView(QWidget):
         
         # Menu Validation for sample
         if header_name_match_sample:
-            if validation_menu_lock:
-                QMessageBox.information(
-                    self, "sample locked", self.tr(f"Sample '{sample_name}' is locked")
-                )
-            else:
-                self._show_sample_variant_dialog()
+            # if validation_menu_lock:
+            #     QMessageBox.information(
+            #         self, "sample locked", self.tr(f"Sample '{sample_name}' is locked")
+            #     )
+            # else:
+            self._show_sample_variant_dialog()
         else:
             self._show_variant_dialog()
 

--- a/cutevariant/gui/plugins/vql_history/widgets.py
+++ b/cutevariant/gui/plugins/vql_history/widgets.py
@@ -163,8 +163,6 @@ class HistoryModel(QAbstractTableModel):
         self.records.insert(0, [tags, time, perf_time, query, count])
         self.endInsertRows()
 
-        print("TAGS", self.rowCount())
-
     def from_json(self, records: dict):
         """Load from a json serialisable object"""
 

--- a/cutevariant/gui/widgets/dict_widget.py
+++ b/cutevariant/gui/widgets/dict_widget.py
@@ -133,7 +133,6 @@ class DictWidget(QWidget):
         _layout.setContentsMargins(0, 0, 0, 0)
 
         self.setLayout(_layout)
-        print("init")
 
     def set_dict(self, data: dict):
 


### PR DESCRIPTION
Fix Genotype Editor:
- Add Sample ans Variant on Evaluation Tab
- Add Variant infos/annotations Tab
- Add Sample infos

Fix lock feature on plugins
- Genotypes plugin contextual menu lock
- Variant plugin contextual menu lock on gt field (relax)

Some fixes (print):
- Dict widget
- VQL history