### PR TITLE
fix tag locked on edit when sample lock

### DIFF
--- a/cutevariant/gui/widgets/sample_variant_widget.py
+++ b/cutevariant/gui/widgets/sample_variant_widget.py
@@ -161,7 +161,7 @@ class EvaluationSectionWidget(AbstractSectionWidget):
 
         if self.is_locked(genotype["sample_id"]):
             self.setToolTip("Genotype can't be edited because the sample is locked")
-            # self.tag_edit.setReadOnly(True)
+            self.tag_edit.setDisabled(True)
             self.comment.preview_btn.setDisabled(True)
             self.class_combo.setDisabled(True)
 

--- a/cutevariant/gui/widgets/sample_widget.py
+++ b/cutevariant/gui/widgets/sample_widget.py
@@ -182,7 +182,7 @@ class EvaluationSectionWidget(AbstractSectionWidget):
 
         if is_locked(self,sample["id"]):
             self.setToolTip(LOCK_TOOLTIP_MESSAGE)
-            # self.tag_edit.setReadOnly(True)
+            self.tag_edit.setDisabled(True)
             self.comment.preview_btn.setDisabled(True)
 
 


### PR DESCRIPTION
Fix lock of tags on Edit (samples and genotypes) when a sample is classified with a lock option