### PR TITLE
Fix editor titles and common variant name function

### DIFF
--- a/cutevariant/gui/plugins/variant_view/widgets.py
+++ b/cutevariant/gui/plugins/variant_view/widgets.py
@@ -1322,28 +1322,10 @@ class VariantView(QWidget):
         """Create a menu when clicking on a variant line"""
         menu = QMenu(self)
 
-        config = Config("variables") or {}
-        formatted_variant = config.get("variant_name_pattern", "{chr}:{pos} - {ref}>{alt}")
-
         current_variant = self.model.variant(index.row())
 
-        if re.findall("ann.", formatted_variant):
-            full_variant = sql.get_variant(
-                self.conn, current_variant["id"], with_annotations=True
-            )  # Need with_annotations=True for variant name
-            if len(full_variant.get("annotations", [{}])):
-                for ann in full_variant.get("annotations", [{}])[0]:
-                    full_variant["annotations___" + str(ann)] = full_variant.get(
-                        "annotations", [{}]
-                    )[0][ann]
-                formatted_variant = formatted_variant.replace("ann.", "annotations___")
-        else:
-            full_variant = sql.get_variant(self.conn, current_variant["id"])
-        # Update variant with currently displayed fields (not in variants table)
-        full_variant.update(current_variant)
-
-        # variant_name
-        variant_name = formatted_variant.format(**full_variant)
+        # Get variant name
+        variant_name = cm.find_variant_name(conn=self.conn, variant_id=current_variant["id"], troncate=True)
 
         menu.addAction(
             FIcon(0xF064F),

--- a/cutevariant/gui/widgets/sample_widget.py
+++ b/cutevariant/gui/widgets/sample_widget.py
@@ -20,6 +20,7 @@ from cutevariant.gui.widgets import ChoiceButton
 from cutevariant import gui
 
 import cutevariant.constants as cst
+from cutevariant import commons as cm
 from cutevariant.gui.formatters.cutestyle import CutestyleFormatter
 
 from cutevariant.gui import tooltip as toolTip
@@ -388,21 +389,8 @@ class OccurenceModel(QAbstractTableModel):
         if role == Qt.DisplayRole:
             if index.column() == OccurenceModel.VARIANT_COLUMN:
                 variant_id = item.get("variant_id", "error")
-                variant_text = str(variant_id)
-
-                # Get variant_name_pattern
-                config = Config("variables") or {}
-                variant_name_pattern = (
-                    config.get("variant_name_pattern") or "{chr}:{pos} - {ref}>{alt}"
-                )
-
-                # Get fields
-                variant = sql.get_variant(self._parent.conn, variant_id, with_annotations=True)
-                if len(variant["annotations"]):
-                    for ann in variant["annotations"][0]:
-                        variant["annotations___" + str(ann)] = variant["annotations"][0][ann]
-                variant_name_pattern = variant_name_pattern.replace("ann.", "annotations___")
-                variant_text = variant_name_pattern.format(**variant)
+                # variant_text = str(variant_id)
+                variant_text = cm.find_variant_name(conn=self._parent.conn, variant_id=variant_id, troncate=False)
                 return variant_text
 
             if index.column() == OccurenceModel.CLASSIFICATION_COLUMN:
@@ -619,7 +607,7 @@ class SampleWidget(QWidget):
         self.last_sample_hash = self.get_sample_hash(sample)
 
         # # Set name
-        name = "{name}".format(**sample)
+        name = "Sample edition - {name}".format(**sample)
         self.setWindowTitle(name)
 
         for widget in self._section_widgets:

--- a/cutevariant/gui/widgets/sample_widget.py
+++ b/cutevariant/gui/widgets/sample_widget.py
@@ -389,7 +389,6 @@ class OccurenceModel(QAbstractTableModel):
         if role == Qt.DisplayRole:
             if index.column() == OccurenceModel.VARIANT_COLUMN:
                 variant_id = item.get("variant_id", "error")
-                # variant_text = str(variant_id)
                 variant_text = cm.find_variant_name(conn=self._parent.conn, variant_id=variant_id, troncate=False)
                 return variant_text
 

--- a/cutevariant/gui/widgets/variant_widget.py
+++ b/cutevariant/gui/widgets/variant_widget.py
@@ -108,21 +108,9 @@ class EvaluationSectionWidget(AbstractSectionWidget):
 
         # Load variant
         if "id" in variant:
-
-            # variant_id
+            # find variant name
             variant_id = variant["id"]
-
-            # Get variant_name_pattern
-            config = Config("variables") or {}
-            variant_name_pattern = config.get("variant_name_pattern") or "{chr}:{pos} - {ref}>{alt}"
-
-            # Get fields
-            variant = sql.get_variant(self.conn, variant_id, with_annotations=True)
-            if len(variant["annotations"]):
-                for ann in variant["annotations"][0]:
-                    variant["annotations___" + str(ann)] = variant["annotations"][0][ann]
-            variant_name_pattern = variant_name_pattern.replace("ann.", "annotations___")
-            variant_text = variant_name_pattern.format(**variant)
+            variant_text = cm.find_variant_name(conn=self.conn, variant_id=variant_id, troncate=False)
             self.variant_label.setText(variant_text)
 
         # Load favorite
@@ -552,9 +540,9 @@ class VariantWidget(QWidget):
         variant = sql.get_variant(self._conn, variant_id, with_annotations=True, with_samples=True)
         self.last_variant_hash = self.get_variant_hash(variant)
 
-        # # Set name
-        # name = "{chr}-{pos}-{ref}-{alt}".format(**variant)
-        self.setWindowTitle("Variant edition")
+        variant_name = cm.find_variant_name(conn=self.conn, variant_id=variant_id, troncate=True)
+
+        self.setWindowTitle(f"Variant edition - {variant_name}")
 
         for widget in self._section_widgets:
             widget.set_variant(variant)


### PR DESCRIPTION
Fix editor titles to homogenize text
Example:
- "Sample edition - Sample1"
- "Variant edition - NRAS:NM_123546:c.123A>T:p.S123S"
- "Genotype edition - Sample1 - NRAS:NM_123546:c.123A>T:p.S123S"

Add common function to find variant name (in commons.py)
- use pattern in settings
- check if pattern use annotations
- truncate if needed (default 40 characters)