### PR TITLE
fix doubleclick lines samples, variants, genotypes

### DIFF
--- a/cutevariant/gui/plugins/genotypes/settings.py
+++ b/cutevariant/gui/plugins/genotypes/settings.py
@@ -1,9 +1,8 @@
 ## ================= Settings widgets ===================
 # Qt imports
 from typing import List
-from PySide6.QtCore import *
 from PySide6.QtGui import QColor, QFont, QIcon, QPixmap
-from PySide6.QtWidgets import *
+from PySide6.QtWidgets import QFormLayout, QComboBox
 
 # Custom imports
 from cutevariant.gui.plugin import PluginSettingsWidget
@@ -40,7 +39,6 @@ class GeneralSettings(AbstractSettingsWidget):
         self.classifications_genotypes_list = list(self.classifications_genotypes_dict)
  
         self.classifications_combobox = QComboBox()
-        f_layout = QFormLayout()
 
         f_layout = QFormLayout(self)
         f_layout.addRow(self.tr("Default Classification"), self.classifications_combobox)

--- a/cutevariant/gui/plugins/genotypes/settings.py
+++ b/cutevariant/gui/plugins/genotypes/settings.py
@@ -1,0 +1,86 @@
+## ================= Settings widgets ===================
+# Qt imports
+from typing import List
+from PySide6.QtCore import *
+from PySide6.QtGui import QColor, QFont, QIcon, QPixmap
+from PySide6.QtWidgets import *
+
+# Custom imports
+from cutevariant.gui.plugin import PluginSettingsWidget
+from cutevariant.gui.settings import AbstractSettingsWidget
+from cutevariant.gui import FIcon
+import cutevariant.constants as cst
+from cutevariant.config import Config
+
+from cutevariant.gui.widgets import ClassificationEditor
+
+from cutevariant import LOGGER
+
+import typing
+import copy
+
+
+class GeneralSettings(AbstractSettingsWidget):
+    def __init__(self):
+        super().__init__()
+        self.setWindowTitle(self.tr("General"))
+        self.setWindowIcon(FIcon(0xF070F))
+
+        # Classification
+        classifications = Config("classifications")
+        classifications_genotypes = classifications.get("genotypes", [])
+        self.classifications_genotypes_dict = {
+            classification["name"]: classification["number"]
+            for classification in classifications_genotypes
+        }
+        self.classifications_genotypes_dict_inv = {
+            classification["number"]: classification["name"]
+            for classification in classifications_genotypes
+        }
+        self.classifications_genotypes_list = list(self.classifications_genotypes_dict)
+ 
+        self.classifications_combobox = QComboBox()
+        f_layout = QFormLayout()
+
+        f_layout = QFormLayout(self)
+        f_layout.addRow(self.tr("Default Classification"), self.classifications_combobox)
+
+    def save(self):
+        config = self.section_widget.create_config()
+
+        # Classification
+        config["default_classification_validation"] = self.classifications_genotypes_dict.get(self.classifications_combobox.currentText(),0)
+        
+        config.save()
+
+    def load(self):
+
+        # Classification
+        self.classifications_combobox.clear()
+        self.classifications_combobox.addItems(self.classifications_genotypes_list)
+        config = Config("genotypes")
+        classification = config.get("default_classification_validation", 0)
+        classification_name = self.classifications_genotypes_dict_inv.get(classification, "unknown")
+        try:
+            classification_index = self.classifications_genotypes_list.index(classification_name)
+            self.classifications_combobox.setCurrentIndex(classification_index)
+        except ValueError:
+            LOGGER.debug("Genotypes Classification not found")
+        
+
+
+class GenotypesSettingsWidget(PluginSettingsWidget):
+    """Instantiated plugin in the settings panel of Cutevariant
+
+    Allow users to set predefined masks for urls pointing in various databases
+    of variants.
+    """
+
+    ENABLE = True
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setWindowIcon(FIcon(0xF0AA1))
+        self.setWindowTitle("Genotypes")
+        self.add_page(GeneralSettings())
+

--- a/cutevariant/gui/plugins/samples/widgets.py
+++ b/cutevariant/gui/plugins/samples/widgets.py
@@ -462,8 +462,8 @@ class SamplesWidget(plugin.PluginWidget):
 
         menu = QMenu(self)
 
-        #menu.addAction(FIcon(0xF064F), f"Edit Sample '{sample_name}'", self.on_edit)
-        menu.addAction(FIcon(0xF064F), f"Edit Sample '{sample_name}'", self.on_double_clicked) 
+        menu.addAction(FIcon(0xF064F), f"Edit Sample '{sample_name}'", self.on_edit)
+        #menu.addAction(FIcon(0xF064F), f"Edit Sample '{sample_name}'", self.on_double_clicked) 
 
         menu.addMenu(self._create_classification_menu(sample))
         if not self.is_locked(sample_id):
@@ -511,7 +511,8 @@ class SamplesWidget(plugin.PluginWidget):
         """
         Action on default doubleClick
         """
-        self.on_edit()
+        #self.on_edit()
+        self.on_show_variant()
 
     def on_double_clicked_vertical_header(self):
         """

--- a/cutevariant/gui/plugins/variant_view/widgets.py
+++ b/cutevariant/gui/plugins/variant_view/widgets.py
@@ -1744,7 +1744,8 @@ class VariantView(QWidget):
         """
         Action on default doubleClick
         """
-        self.open_editor(index)
+        #self.open_editor(index)
+        self.update_favorites()
 
     def on_double_clicked_vertical_header(self, index: QModelIndex):
         """


### PR DESCRIPTION
Add actions on doubleClick on lines for samples, variants and genotypes
Add settings on genotypes for variable corresponding to default classification when doubleClick

![double_click_on_plugins_lines](https://user-images.githubusercontent.com/40463532/174893875-3d6af530-1972-4237-a470-017f734099c9.gif)

![double_click_on_plugins_lines_genotypes_settings](https://user-images.githubusercontent.com/40463532/174893925-537fb527-1cd7-40e9-8abb-020ebc7cdd55.gif)


