### PR TITLE
fix bug on toolbar search name

### DIFF
--- a/cutevariant/gui/mainwindow.py
+++ b/cutevariant/gui/mainwindow.py
@@ -190,6 +190,7 @@ class MainWindow(QMainWindow):
         )
 
         search_bar = self.addToolBar("Search")
+        search_bar.setObjectName("search")
         search_bar.addWidget(self.quick_search_edit)
 
         # Window geometry


### PR DESCRIPTION
Fix bug on toolbar search:
```
QMainWindow::saveState(): 'objectName' not set for QToolBar 0x60000352fea0 'Search'
```