### PR TITLE
fix selection source on double click

### DIFF
--- a/cutevariant/gui/plugins/source_editor/widgets.py
+++ b/cutevariant/gui/plugins/source_editor/widgets.py
@@ -128,6 +128,8 @@ class SourceModel(QAbstractTableModel):
             font = QFont()
             if table_name == self.current_source:
                 font.setBold(True)
+            else:
+                font.setBold(False)
             return font
 
         if role == Qt.ForegroundRole:
@@ -365,7 +367,7 @@ class SourceEditorWidget(plugin.PluginWidget):
 
     @Slot(QModelIndex)
     def on_double_click(self, current: QModelIndex):
-        source = current.data(Qt.DisplayRole)
+        source = self.model.records[current.row()].get("name","unknown")
         if source:
             self.model.current_source = source
             self.mainwindow.set_state_data("source", source)


### PR DESCRIPTION
Fix selection of a source on double click on samples plugin

TODO: Bold style error when changing source

<img width="406" alt="image" src="https://user-images.githubusercontent.com/40463532/175394019-30099999-1e5f-4987-82db-d0576e313a86.png">
