### PR TITLE
add style for genotypes on variant view

### DIFF
--- a/cutevariant/gui/formatters/cutestyle.py
+++ b/cutevariant/gui/formatters/cutestyle.py
@@ -79,18 +79,13 @@ class CutestyleFormatter(Formatter):
 
         if re.match(r"samples\..+\.classification", field):
             if value == "NULL":
-                genotype_classification_name = ""
-                genotype_classification_color = "gray"
-                genotype_classification_icon = "" #0xF0130
                 return {"text": ""}
             else:
-                genotype_classification_name = self.CLASSIFICATIONS_GENOTYPES.get(int(value),{}).get("name","unknown")
                 genotype_classification_color = self.CLASSIFICATIONS_GENOTYPES.get(int(value),{}).get("color","gray")
                 if int(value) != 0:
                     genotype_classification_icon = 0xF0133
                 else:
                     genotype_classification_icon = 0xF0130 #0xF0130 #0xF012F
-                value = genotype_classification_name
                 return {"text": "", "color": genotype_classification_color, "icon": FIcon(genotype_classification_icon, color=genotype_classification_color)}
 
         if value == "NULL" or value == "None":

--- a/cutevariant/gui/formatters/cutestyle.py
+++ b/cutevariant/gui/formatters/cutestyle.py
@@ -63,6 +63,12 @@ class CutestyleFormatter(Formatter):
         ):
             self.TAGS_COLOR[tag["name"]] = tag["color"]
 
+         # Classification genotypes
+        self.CLASSIFICATIONS_GENOTYPES = {}
+        classifications_genotypes = Config("classifications").get("genotypes", None)
+        for classification in classifications_genotypes:
+            self.CLASSIFICATIONS_GENOTYPES[classification["number"]] = classification
+
     def format(self, field: str, value: str, option, is_selected):
 
         if re.match(r"samples\..+\.gt", field) or field == "gt":
@@ -70,6 +76,16 @@ class CutestyleFormatter(Formatter):
                 value = -1
             icon = cst.GENOTYPE_ICONS.get(int(value))
             return {"text": "", "icon": FIcon(icon)}
+
+        if re.match(r"samples\..+\.classification", field):
+            genotype_classification_name = self.CLASSIFICATIONS_GENOTYPES.get(int(value),{}).get("name","unknown")
+            genotype_classification_color = self.CLASSIFICATIONS_GENOTYPES.get(int(value),{}).get("color","gray")
+            if int(value) != 0:
+                genotype_classification_icon = 0xF0133
+            else:
+                genotype_classification_icon = 0xF0130 #0xF0130 #0xF012F
+            value = genotype_classification_name
+            return {"text": "", "color": genotype_classification_color, "icon": FIcon(genotype_classification_icon, color=genotype_classification_color)}
 
         if value == "NULL" or value == "None":
             font = QFont()

--- a/cutevariant/gui/formatters/cutestyle.py
+++ b/cutevariant/gui/formatters/cutestyle.py
@@ -78,14 +78,20 @@ class CutestyleFormatter(Formatter):
             return {"text": "", "icon": FIcon(icon)}
 
         if re.match(r"samples\..+\.classification", field):
-            genotype_classification_name = self.CLASSIFICATIONS_GENOTYPES.get(int(value),{}).get("name","unknown")
-            genotype_classification_color = self.CLASSIFICATIONS_GENOTYPES.get(int(value),{}).get("color","gray")
-            if int(value) != 0:
-                genotype_classification_icon = 0xF0133
+            if value == "NULL":
+                genotype_classification_name = ""
+                genotype_classification_color = "gray"
+                genotype_classification_icon = "" #0xF0130
+                return {"text": ""}
             else:
-                genotype_classification_icon = 0xF0130 #0xF0130 #0xF012F
-            value = genotype_classification_name
-            return {"text": "", "color": genotype_classification_color, "icon": FIcon(genotype_classification_icon, color=genotype_classification_color)}
+                genotype_classification_name = self.CLASSIFICATIONS_GENOTYPES.get(int(value),{}).get("name","unknown")
+                genotype_classification_color = self.CLASSIFICATIONS_GENOTYPES.get(int(value),{}).get("color","gray")
+                if int(value) != 0:
+                    genotype_classification_icon = 0xF0133
+                else:
+                    genotype_classification_icon = 0xF0130 #0xF0130 #0xF012F
+                value = genotype_classification_name
+                return {"text": "", "color": genotype_classification_color, "icon": FIcon(genotype_classification_icon, color=genotype_classification_color)}
 
         if value == "NULL" or value == "None":
             font = QFont()


### PR DESCRIPTION
Add icon and color on genotypes on variant view:
- Color depend on genotypes classifications
- Icon depend on value (classification number) and checked if != 0

As genotype classification field can be added for multiple samples, and with filter "count_validation_positive > 0", all validated variant can be easily selected for a full set of samples (e.g. run, trio)

<img width="1418" alt="image" src="https://user-images.githubusercontent.com/40463532/175816122-5c143c45-4a7b-4ee1-b7c1-7548b75dc986.png">

